### PR TITLE
feat: add preprend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,24 @@ jobs:
           edit-mode: append
           append-separator: newline
 
+      - name: Test prepend body with space separator
+        uses: ./
+        with:
+          issue-number: 1
+          body: |
+            _Text prepended with space separator_
+          edit-mode: prepend
+          prepend-separator: space
+  
+      - name: Test prepend body with newline separator
+        uses: ./
+        with:
+          issue-number: 1
+          body: |
+            **Text prepended with newline separator**
+          edit-mode: prepend
+          prepend-separator: newline
+
   package:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [test]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,19 @@ _This is heavily based on [peter-evans/create-or-update-comment](https://github.
     append-separator: space
 ```
 
+### Preprend content to issue body
+
+```yaml
+- name: Preprend Issue Body
+  uses: julien-deramond/update-issue-body@v1
+  with:
+    issue-number: ${{ github.event.issue.number }}
+    body: |
+      **Edit**: Prepend some new content separated by a space
+    edit-mode: prepend
+    append-separator: space
+```
+
 ### Action inputs
 
 | Name | Description | Default |
@@ -42,8 +55,9 @@ _This is heavily based on [peter-evans/create-or-update-comment](https://github.
 | `repository` | The full name of the repository in which to update the issue body. | Current repository |
 | `issue-number` | The number of the issue to be updated. | |
 | `body` | The issue body. | |
-| `edit-mode` | The mode when updating the issue body, `replace` or `append`. | `append` |
+| `edit-mode` | The mode when updating the issue body, `replace`, `append` or `prepend`. | `append` |
 | `append-separator` | The separator to use when appending to an existing issue body. (`newline`, `space`, `none`) | `newline` |
+| `prepend-separator` | The separator to use when prepending to an existing issue body. (`newline`, `space`, `none`) | `newline` |
 
 
 ### Accessing issues in other repositories

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ _This is heavily based on [peter-evans/create-or-update-comment](https://github.
     append-separator: space
 ```
 
-### Preprend content to issue body
+### Prepend content to issue body
 
 ```yaml
-- name: Preprend Issue Body
+- name: Prepend Issue Body
   uses: julien-deramond/update-issue-body@v1
   with:
     issue-number: ${{ github.event.issue.number }}

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,11 @@ inputs:
   body:
     description: 'The issue body.'
   edit-mode:
-    description: 'The mode when updating the issue body, "replace" or "append".'
+    description: 'The mode when updating the issue body, "replace", "append" or "prepend".'
     default: 'append'
+  prepend-separator:
+    description: 'The separator to use when prepending to an existing issue body. (`newline`, `space`, `none`)'
+    default: 'newline'
   append-separator:
     description: 'The separator to use when appending to an existing issue body. (`newline`, `space`, `none`)'
     default: 'newline'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "update-issue-body",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "update-issue-body",
-      "version": "0.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "update-issue-body",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "description": "Update an issue body",
   "main": "lib/main.js",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,16 +19,22 @@ async function run(): Promise<void> {
       issueNumber: Number(core.getInput('issue-number')),
       body: core.getInput('body'),
       editMode: core.getInput('edit-mode'),
-      appendSeparator: core.getInput('append-separator')
+      appendSeparator: core.getInput('append-separator'),
+      prependSeparator: core.getInput('prepend-separator')
     }
+
     core.debug(`Inputs: ${inspect(inputs)}`)
 
-    if (!['append', 'replace'].includes(inputs.editMode)) {
+    if (!['append', 'prepend', 'replace'].includes(inputs.editMode)) {
       throw new Error(`Invalid edit-mode '${inputs.editMode}'.`)
     }
 
     if (!['newline', 'space', 'none'].includes(inputs.appendSeparator)) {
       throw new Error(`Invalid append-separator '${inputs.appendSeparator}'.`)
+    }
+
+    if (!['newline', 'space', 'none'].includes(inputs.prependSeparator)) {
+      throw new Error(`Invalid prepend-separator '${inputs.prependSeparator}'.`)
     }
 
     const body = getBody(inputs)

--- a/src/update-issue-body.ts
+++ b/src/update-issue-body.ts
@@ -56,8 +56,7 @@ async function updateBody(
         issue.body ? issue.body : '',
         appendSeparator
       )
-    }
-    else if (editMode == 'prepend') {
+    } else if (editMode == 'prepend') {
       // Get the issue body
       const {data: issue} = await octokit.rest.issues.get({
         owner: owner,


### PR DESCRIPTION
Closes #3 

This PR allows to prepend content to the issue body with the same options as for the append feature:
- New `edit-mode` value: "prepend"
- New `prepend-separator` option with the following possible values: `newline`, `space`, `none` (same as for append)

Non-breaking, this feature will land in a v1.1.